### PR TITLE
Add metadata to acceptance criteria document

### DIFF
--- a/context-engineering/01-requirements/acceptance-criteria-detailed.md
+++ b/context-engineering/01-requirements/acceptance-criteria-detailed.md
@@ -1,5 +1,9 @@
 # Comprehensive Acceptance Criteria - Personal AI Chatbot
 
+> **Status**: ✅ Complete - Comprehensive acceptance criteria finalized and validated
+> **Phase**: Context Engineering - Requirements Analysis
+> **Dependencies**: Product Requirements Document (Complete), Exhaustive User Stories, Edge Cases Catalog
+
 ## Overview
 
 This document defines exhaustive acceptance criteria for the Personal AI Chatbot application, covering all functional and non-functional requirements with measurable success metrics, comprehensive test scenarios, validation methods, and failure thresholds. The criteria ensure 99.9% coverage of all user journeys, business rules, edge cases, and technical specifications.


### PR DESCRIPTION
## Summary
- add the standard metadata block to the comprehensive acceptance criteria document
- mark the document as complete and reference its related requirements artifacts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdfd60445483229ac5abb02d5e2100