### PR TITLE
docs: record automated test results

### DIFF
--- a/TEST_RESULTS.md
+++ b/TEST_RESULTS.md
@@ -1,0 +1,43 @@
+# Test Suite Execution Report
+
+## Environment
+- **Date**: 2025-09-20 13:36:12Z
+- **Python**: 3.12.10 (from `pytest` session header)
+- **Platform**: Linux (containerized CI environment)
+
+## Commands Executed
+1. `pip install -r requirements.txt`
+   - Installed application and testing dependencies successfully.
+2. `python -m pytest tests/`
+   - Attempted to run the complete pytest suite under the `tests/` directory.
+
+## Outcome Summary
+- **Overall Result**: ❌ Test execution failed during collection with 25 errors.
+- **Pytest Output Highlights**:
+  - Test session initialized with `pytest-8.4.1` and plugin `anyio-4.10.0`.
+  - Collection stopped early due to import and dependency issues before any tests were executed.
+
+## Detailed Failures
+### Import Errors
+- Multiple test modules failed to import `src.core.controllers.chat_controller` because the module performs a relative import (`from ...utils.logging import logger`) that resolves beyond the package root. This affects unit, integration, performance, and accessibility test suites.
+- Example affected files:
+  - `tests/unit/test_api_client_manager.py`
+  - `tests/unit/test_chat_controller.py`
+  - `tests/accessibility/test_wcag_compliance.py`
+  - `tests/performance/test_ui_performance.py`
+
+### Missing Dependencies
+- `tests/integration/test_phase7_system_integration.py` and `tests/performance/test_performance_validation_phase7.py` require the `psutil` package, which is not listed in `requirements.txt`, leading to `ModuleNotFoundError: No module named 'psutil'` during collection.
+
+### Syntax Error in Test Suite
+- `tests/integration/test_ui_chat_controller_integration.py` contains an `await` expression outside of an `async def` function, triggering a syntax error that prevents the file from importing.
+
+### Additional Pytest Warnings
+- Several tests in `tests/integration/test_scenarios_e2e_user_journeys.py` use the custom mark `@pytest.mark.e2e` without registering it, producing `PytestUnknownMarkWarning`. While not blocking execution, these warnings indicate missing mark configuration in `pytest.ini` or `pyproject.toml`.
+
+## Next Steps
+- Update `src/core/controllers/chat_controller.py` and related modules to avoid relative imports that traverse beyond the package root, or adjust the package structure to make those imports valid.
+- Add `psutil` (and any other missing runtime dependencies) to `requirements.txt` or test-specific dependency files.
+- Correct the asynchronous test in `tests/integration/test_ui_chat_controller_integration.py` to ensure that `await` statements appear within `async def` functions.
+- Register the `e2e` pytest mark in the project's configuration to silence the warnings and clarify test categorization.
+


### PR DESCRIPTION
## Summary
- install project dependencies and execute the full pytest suite
- capture collection-time failures and dependency gaps in TEST_RESULTS.md

## Testing
- python -m pytest tests/ *(fails: collection aborted with 25 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cead66d9b48322a765b30a26793af5