### PR TITLE
chore: add psutil to managed test dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+.env
+.env.*
+*.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ All core functionality is implemented and production-ready.
 ## Installation
 
 ```bash
-pip install -r requirements.txt
+pip install -e .[test]
 ```
+
+This editable install pulls in the optional testing dependencies, ensuring packages like `psutil` are always available during development and continuous integration runs.
 
 ## Usage
 
@@ -125,6 +127,9 @@ The application will start a local web server and open your default browser to t
 The project includes comprehensive testing coverage:
 
 ```bash
+# Install dependencies (if not already installed)
+pip install -e .[test]
+
 # Run all tests
 python -m pytest tests/
 

--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -590,8 +590,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-cov
+          pip install -e .[test]
       - name: Run integration tests
         run: pytest tests/integration/ -v --cov=src --cov-report=xml
       - name: Upload coverage

--- a/docs/testing-standards.md
+++ b/docs/testing-standards.md
@@ -348,8 +348,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest pytest-cov
+          pip install -e .[test]
       - name: Run tests
         run: pytest --cov=src --cov-report=xml
       - name: Upload coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "personal-ai-chatbot"
+version = "1.0.0"
+description = "Personal AI chatbot application with Gradio interface and monitoring utilities."
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "gradio>=5.0.0",
+    "openai>=1.0.0",
+    "python-dotenv>=1.0.0",
+    "requests>=2.31.0",
+    "cryptography>=41.0.0",
+    "psutil>=5.9",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "pytest-cov>=4.1",
+    "psutil>=5.9",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openai>=1.0.0
 python-dotenv>=1.0.0
 requests>=2.31.0
 cryptography>=41.0.0
+psutil>=5.9


### PR DESCRIPTION
## Summary
- declare project metadata with optional test dependencies that include psutil
- align developer documentation to install the editable test extra during setup
- retain legacy requirements file with psutil and add a gitignore for virtualenv artefacts

## Testing
- pytest *(fails: ModuleNotFoundError for src and SyntaxError in existing test file)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb3ada87483228bb14f4387c917e3