### PR TITLE
Configure pytest markers for e2e tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,12 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = [
+    "--strict-markers",
+]
+markers = [
+    "e2e: end-to-end tests",
+    "asyncio: mark tests that require asyncio event loop",
+]


### PR DESCRIPTION
## Summary
- register pytest markers for end-to-end and asyncio test suites in the pytest configuration
- enable strict marker checking so unregistered markers raise failures during test collection

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'src'; ModuleNotFoundError: No module named 'psutil')*


------
https://chatgpt.com/codex/tasks/task_e_68ceb70d7d4483229a61a5d67af20126