### PR TITLE
Configure pytest asyncio auto mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ python -m pytest tests/accessibility/ # Accessibility tests
 # Generate coverage report
 python -m pytest --cov=src --cov-report=html
 ```
+Pytest is configured with `asyncio_mode = "auto"`, enabling `pytest-asyncio` to manage event loops without manual fixtures. This prevents conflicts when tests mix synchronous and asynchronous cases, especially when an event loop is already running.
 
 ### Test Coverage
 - **Unit Tests**: Component-level functionality testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ include-package-data = true
 where = ["src"]
 
 [tool.pytest.ini_options]
+asyncio_mode = "auto"
 addopts = [
     "--strict-markers",
 ]


### PR DESCRIPTION
## Summary
- configure pytest to use `asyncio_mode = "auto"` so event loops are managed automatically
- document the pytest asyncio configuration rationale in the testing section of the README

## Testing
- python -m pytest -q *(fails: suite has numerous pre-existing failures; command interrupted after confirming configuration loads)*

------
https://chatgpt.com/codex/tasks/task_e_68ced21534ac8322bb80e58b9d280708