### PR TITLE
Update test report after latest pytest execution

### DIFF
--- a/TEST_RESULTS.md
+++ b/TEST_RESULTS.md
@@ -1,53 +1,49 @@
 # Test Suite Execution Report
 
 ## Environment
-- **Date**: 2025-09-20 14:25:56Z
-- **Python**: 3.12.10 (from `pytest` session header)
+- **Date**: 2025-09-20 16:24:05Z (UTC)
+- **Python**: 3.12.10 (pytest 8.4.1)
 - **Platform**: Linux (containerized CI environment)
 
 ## Commands Executed
 1. `pip install -r requirements.txt`
-   - Ensured runtime dependencies (including `psutil`) are installed.
+   - Confirmed all runtime dependencies were present; `psutil` 7.1.0 was (re)installed.
 2. `pip install -e .[test]`
-   - Installed the project in editable mode with all testing extras.
+   - Installed the project in editable mode alongside the pytest extras (`pytest-asyncio`, `pytest-cov`, `coverage`).
 3. `python -m pytest`
-   - Launched the full pytest test suite. Pytest reported summary results after 215.75s, at which point the run was manually terminated via `KeyboardInterrupt` to return control to the shell.
+   - Pytest collected **516 tests** but the process was terminated by the operating system with a `Killed` signal while executing `tests/unit/test_events.py` after ~4 minutes of CPU time.
+   - Prior to termination, the live progress indicators showed numerous failures across the suite:
+     - Accessibility: 3 failing checks in `tests/accessibility/test_wcag_compliance.py`.
+     - Integration: `tests/integration/test_error_scenarios_phase7.py` (≈8 fails), `test_phase5_integration.py` (1 fail), `test_phase7_system_integration.py` (≈8 fails), `test_scenarios_e2e_user_journeys.py` (≈9 fails), `test_ui_chat_controller_integration.py` (≈5 fails).
+     - Performance: `tests/performance/test_performance_validation_phase7.py` (≈9 fails) while `test_ui_performance.py` passed.
+     - Unit: Failures observed in `test_api_client_manager.py` (4), `test_backup_manager.py` (2), `test_chat_controller.py` (10), `test_config_manager.py` (2), `test_conversation_manager.py` (1), `test_error_handler.py` (5), and `test_events.py` (at least 7 before termination). `test_chat_panel.py` and `test_conversation_storage.py` showed all passing indicators before the run stopped.
+   - Because the runner was killed abruptly, pytest did **not** emit individual failure tracebacks or a summary table; deeper diagnostics require targeted re-runs.
+4. `python -m pytest tests/accessibility/test_wcag_compliance.py -vv`
+   - Targeted follow-up to capture at least one concrete failure reason: 3 tests failed because `InputPanel` lacks the `message_input` attribute expected by the accessibility checks.
 
 ## Outcome Summary
-- **Overall Result**: ❌ Pytest reported **53 failed**, **210 passed**, **38 errors**, and **19 warnings** before the run was interrupted.
-- **Runtime**: 215.75 seconds prior to the `KeyboardInterrupt` (the reported totals reflect tests executed up to that point).
+- **Overall Result**: ❌ Incomplete — full-suite run ended with an OS-level `Killed` signal before pytest could report totals or tracebacks.
+- **Runtime**: ~4 minutes of execution prior to termination.
+- **Impact**: Large portions of the integration, performance, and unit suites remain red; accessibility failures are confirmed via targeted rerun.
 
-## Detailed Failures & Errors
+## Detailed Observations
 ### Accessibility Suite (`tests/accessibility/test_wcag_compliance.py`)
-- Three tests (`test_aria_labels_and_roles`, `test_form_labels_and_associations`, `test_input_purpose_identification`) assert that the Gradio input panel exposes a `message_input` control. The current `InputPanel` implementation lacks this attribute, leading to assertion failures.
+- The three failing cases (`test_aria_labels_and_roles`, `test_form_labels_and_associations`, `test_input_purpose_identification`) all assert that `self.ui.input_panel` exposes a `message_input` control. The implementation lacks this attribute, leading to immediate assertion failures.
 
-### Integration Suites
-- **`tests/integration/test_phase7_system_integration.py`**: All checked cases fail during fixture setup because objects returned from async fixtures expose `async_generator` instances instead of initialized managers (`conversation_manager`, `config_manager`, etc.).
-- **`tests/integration/test_ui_chat_controller_integration.py`**: Multiple failures stemming from UI contract mismatches, including missing properties on `GradioInterface`, improper coroutine handling (`'coroutine' object is not subscriptable`), streaming helpers flagged as unsupported (`async def functions are not natively supported`), and inconsistent state list handling (`IndexError`).
-- **`tests/integration/test_error_scenarios_phase7.py`** & **`tests/integration/test_scenarios_e2e_user_journeys.py`**: Every test errors during setup because the required `full_system_app` fixture is undefined.
+### Integration & Performance Suites
+- Progress output indicates concentrated failures across all Phase 5/7 integration flows, UI chat controller scenarios, and performance validation checks. Because the run stopped prematurely, failure stack traces were not captured. Expect fixture initialization issues and contract mismatches similar to prior runs; targeted reruns per module are required to gather specifics.
 
-### Performance Suite (`tests/performance/test_performance_validation_phase7.py`)
-- All tests error at setup for the same missing `full_system_app` fixture dependency used by the integration tests.
+### Unit Suites
+- Managers and controller modules (`APIClientManager`, `BackupManager`, `ChatController`, `ConfigManager`, `ConversationManager`, `ErrorHandler`, `Events`) all showed failing indicators before the runner was killed. No new stack traces were recorded; isolating each module with focused pytest commands is recommended to obtain actionable diagnostics.
 
-### Unit Test Failures
-- **`tests/unit/test_api_client_manager.py`**: Assertion mismatches around chat completion success/failure handling, missing metadata keys, and inconsistent request ID length calculations.
-- **`tests/unit/test_backup_manager.py`**: Integrity verification and deletion scenarios fail (expected success paths assert false results).
-- **`tests/unit/test_chat_controller.py`**: Numerous failures, including `StopIteration` from misconfigured iterators, incorrect API error propagation, unmet expectations for cancellation callbacks, and timestamp/state mismatches.
-- **`tests/unit/test_config_manager.py`**: Directory creation and permission tests fail because configuration files/directories are absent in the test sandbox.
-- **`tests/unit/test_conversation_manager.py`**: Metadata computations yield unexpected values (e.g., duration calculations double expected results).
-- **`tests/unit/test_error_handler.py`**: Error classification assumes nested dictionaries, but the implementation receives plain strings; attempting `.get` on strings raises `AttributeError` and halts retries.
-- **`tests/unit/test_events.py`**: Patching fails due to missing module-level helpers (`uuid`, `datetime`), event bus shutdown leaves cancelled tasks referenced, and event failure statistics are not incremented when callbacks raise exceptions.
-
-### Warnings & Runtime Notes
-- Async event bus tests emit runtime warnings about un-awaited coroutines when mocks replace async interfaces.
-- Custom pytest marks (`@pytest.mark.e2e`) are registered in `pyproject.toml`, so warnings from earlier runs about unknown marks are resolved.
+### Run Termination
+- The `Killed` signal occurred while executing `tests/unit/test_events.py`. This suggests either resource exhaustion (likely OOM) or watchdog intervention. No core dump or stderr message beyond `Killed` was emitted.
 
 ## Next Steps
-- Implement or expose the `message_input` attribute (or update tests) to satisfy accessibility requirements.
-- Define and populate the `full_system_app` fixture (and related async fixtures) so integration and performance suites can construct a complete application context.
-- Align UI integration behavior with test expectations: ensure coroutine-friendly streaming helpers, provide required enums/attributes, and guard against index errors when reading UI state.
-- Audit critical managers (`APIClientManager`, `ChatController`, `ConfigManager`, `ErrorHandler`, `EventBus`) to reconcile their logic with test contracts, especially around error handling, filesystem interactions, and async task lifecycle management.
-- Address runtime warnings by ensuring async helpers are awaited within tests or by adjusting mocks to emulate async behavior correctly.
+- Investigate the cause of the OS-level termination (monitor memory usage during future runs or execute subsets to avoid OOM).
+- Run failing suites individually to capture detailed stack traces (e.g., start with `tests/integration/test_phase7_system_integration.py` and `tests/unit/test_chat_controller.py`).
+- Address the confirmed accessibility regression by exposing the `message_input` attribute (or updating the tests if expectations changed).
+- Prioritize stabilization of integration fixtures (`full_system_app`, async manager setup) and event bus lifecycle handling identified by failing modules.
 
 ## Historical Comparison
-- Previous run (documented earlier) failed during test collection due to import errors and missing dependencies. Those blockers are now resolved—the suite executes—but numerous functional failures remain across accessibility, integration, performance, and unit layers.
+- The previous documented run (2025-09-20 14:25:56Z) completed long enough to report 53 failures and 38 errors before being manually interrupted. The current attempt runs longer but ends abruptly due to an OS kill, preventing pytest from emitting aggregated statistics. Many of the previously reported problem areas remain unresolved.


### PR DESCRIPTION
## Summary
- reran dependency installation steps before executing the project's full pytest suite
- documented that the full-suite run was killed by the OS after collecting 516 tests and summarized failing modules from the live progress output
- captured accessibility failure details via a targeted pytest invocation and refreshed TEST_RESULTS.md accordingly

## Testing
- python -m pytest *(killed by OS after ~4 minutes)*
- python -m pytest tests/accessibility/test_wcag_compliance.py -vv *(fails: 3)*

------
https://chatgpt.com/codex/tasks/task_e_68ced3d8cda883229c591bfde093fdc0