### PR TITLE
Persist empty config when missing

### DIFF
--- a/src/storage/config_manager.py
+++ b/src/storage/config_manager.py
@@ -60,6 +60,8 @@ class ConfigManager:
                 logger.debug("Configuration loaded successfully")
             else:
                 self._config = {}
+                # Persist empty configuration immediately to enforce restrictive permissions
+                self._save_config()
                 logger.info("No existing configuration found, starting fresh")
         except InvalidToken:
             logger.error("Invalid encryption token - configuration may be corrupted")


### PR DESCRIPTION
## Summary
- ensure ConfigManager writes an empty configuration file when none exists to satisfy file existence checks
- preserve restrictive permissions by saving via the existing secure writer

## Testing
- pytest tests/unit/test_config_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68cf0a06fa8c83229abc04feba006f5b