### PR TITLE
Convert error handling integration test to async

### DIFF
--- a/tests/integration/test_ui_chat_controller_integration.py
+++ b/tests/integration/test_ui_chat_controller_integration.py
@@ -140,7 +140,8 @@ class TestUIChatControllerIntegration:
         assert len(events_received) == 1
         assert events_received[0].data["test"] == "data"
 
-    def test_error_handling_integration(self):
+    @pytest.mark.asyncio
+    async def test_error_handling_integration(self):
         """Test error handling integration."""
         # Test error notification
         error_message = "Test error message"
@@ -149,7 +150,7 @@ class TestUIChatControllerIntegration:
         self.ui._show_error_notification(error_message)
 
         # Test with invalid message
-        result = self.ui._handle_send_message("")  # Empty message
+        result = await self.ui._handle_send_message("")  # Empty message
 
         assert result["error"] == "Message cannot be empty"
 


### PR DESCRIPTION
## Summary
- update the error handling integration test to run as an async pytest coroutine
- await the UI send-message handler and assert on the resolved result

## Testing
- pytest tests/integration/test_ui_chat_controller_integration.py::TestUIChatControllerIntegration::test_error_handling_integration *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68cf1289434c83228da56d0283b68bd7