### PR TITLE
Add accessible naming metadata to input action buttons

### DIFF
--- a/tests/accessibility/test_wcag_compliance.py
+++ b/tests/accessibility/test_wcag_compliance.py
@@ -46,6 +46,11 @@ class TestWCAGCompliance:
         assert metadata.get('show_label') is True
         assert metadata.get('container') is True
 
+        action_metadata = self.ui.get_input_action_metadata()
+        assert action_metadata.get('voice', {}).get('accessible_label') == '🎤 Voice input'
+        assert action_metadata.get('attachment', {}).get('accessible_label') == '📎 Attach file'
+        assert action_metadata.get('options', {}).get('accessible_label') == '⚙️ Conversation options'
+
     def test_keyboard_navigation_support(self):
         """Test keyboard navigation support."""
         # Test that components support keyboard navigation


### PR DESCRIPTION
## Summary
- add a helper to label voice, attachment, and options buttons with accessible names
- expose the action button accessibility contract through the Gradio UI adapter
- extend accessibility tests to verify the exposed metadata

## Testing
- pytest tests/accessibility/test_wcag_compliance.py

------
https://chatgpt.com/codex/tasks/task_e_68cf1a49704883228c233f1a49fc0227