### PR TITLE
Fix delete backup handling for missing backups

### DIFF
--- a/src/storage/backup_manager.py
+++ b/src/storage/backup_manager.py
@@ -354,11 +354,16 @@ class BackupManager:
         """Delete a backup."""
         try:
             backup_path = self.backup_dir / backup_name
-            if backup_path.exists():
-                shutil.rmtree(backup_path)
+            if not backup_path.exists():
+                logger.warning(f"Backup {backup_name} does not exist")
+                return False
 
+            shutil.rmtree(backup_path)
+
+            original_count = len(self.backups)
             self.backups = [b for b in self.backups if b['name'] != backup_name]
-            self._save_backup_metadata()
+            if len(self.backups) != original_count:
+                self._save_backup_metadata()
 
             logger.info(f"Deleted backup: {backup_name}")
             return True

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -153,8 +153,12 @@ class TestBackupManager:
 
     def test_delete_nonexistent_backup(self):
         """Test deleting a non-existent backup."""
+        initial_backups = self.backup_manager.list_backups()
+
         result = self.backup_manager.delete_backup("nonexistent")
         assert result is False
+
+        assert self.backup_manager.list_backups() == initial_backups
 
     def test_apply_retention_policy(self):
         """Test applying retention policy."""


### PR DESCRIPTION
## Summary
- prevent BackupManager.delete_backup from reporting success when the backup directory is missing and avoid touching metadata in that case
- extend the delete_nonexistent_backup test to ensure metadata remains unchanged when deletion fails

## Testing
- pytest tests/unit/test_backup_manager.py *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_68cf1cdac92c8322b5d8369dc01ea20d