### PR TITLE
Add event bus publishing to chat controller workflows

### DIFF
--- a/src/utils/events.py
+++ b/src/utils/events.py
@@ -376,7 +376,8 @@ event_bus = EventBus()
 
 async def publish_event(event_type: EventType, data: Dict[str, Any],
                        priority: EventPriority = EventPriority.NORMAL,
-                       source: str = "unknown") -> None:
+                       source: str = "unknown",
+                       event_bus_instance: Optional[EventBus] = None) -> None:
     """
     Convenience function to publish an event.
 
@@ -386,13 +387,15 @@ async def publish_event(event_type: EventType, data: Dict[str, Any],
         priority: Event priority
         source: Event source
     """
+    bus = event_bus_instance or event_bus
     event = Event(event_type, data, priority, source)
-    await event_bus.publish(event)
+    await bus.publish(event)
 
 
 def publish_event_sync(event_type: EventType, data: Dict[str, Any],
                       priority: EventPriority = EventPriority.NORMAL,
-                      source: str = "unknown") -> None:
+                      source: str = "unknown",
+                      event_bus_instance: Optional[EventBus] = None) -> None:
     """
     Convenience function to publish an event synchronously.
 
@@ -402,5 +405,6 @@ def publish_event_sync(event_type: EventType, data: Dict[str, Any],
         priority: Event priority
         source: Event source
     """
+    bus = event_bus_instance or event_bus
     event = Event(event_type, data, priority, source)
-    event_bus.publish_sync(event)
+    bus.publish_sync(event)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,7 @@ async def full_system_app(system_config: Dict[str, Any]) -> SimpleNamespace:
             conversation_manager=conversation_manager,
             api_client_manager=api_client_manager,
             state_manager=state_manager,
+            event_bus=event_bus,
         )
 
         # ------------------------------------------------------------------

--- a/tests/integration/test_ui_chat_controller_integration.py
+++ b/tests/integration/test_ui_chat_controller_integration.py
@@ -18,7 +18,7 @@ class TestUIChatControllerIntegration:
     def setup_method(self):
         """Set up test fixtures."""
         self.event_bus = EventBus()
-        self.chat_controller = ChatController()
+        self.chat_controller = ChatController(event_bus=self.event_bus)
         self.ui = GradioInterface(self.chat_controller, self.event_bus)
 
     def test_ui_initialization_with_chat_controller(self):


### PR DESCRIPTION
## Summary
- add an optional EventBus dependency to ChatController and emit user input, API response, and state change events with structured payloads
- extend the publish_event helpers to support injected EventBus instances for easier testing
- pass the shared EventBus through fixtures and integration tests while asserting user/chat streaming event payloads

## Testing
- pytest tests/integration/test_phase7_system_integration.py *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68cf4aa7ef3483228d5511794e0b2912